### PR TITLE
Display all leaderboards, including expired, on index

### DIFF
--- a/kernelboard/index.py
+++ b/kernelboard/index.py
@@ -31,7 +31,6 @@ def index():
         -- Get basic information about active leaderboards.
         active_leaderboards AS (
             SELECT id, name, deadline FROM leaderboard.leaderboard
-            WHERE deadline > NOW()
         ),
 
         -- Get all the GPU types for each leaderboard.

--- a/kernelboard/templates/index.html
+++ b/kernelboard/templates/index.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="content-stack">
-    <h1>Active Leaderboards</h1>
+    <h1>Leaderboards</h1>
     
     <div class="leaderboard-grid">
         {% for leaderboard in leaderboards %}
@@ -17,7 +17,7 @@
                     </div>
 
                     <div class="leaderboard-content">
-                        {{ leaderboard['deadline']|to_time_left }} remaining
+                        {{ leaderboard['deadline']|to_time_left }}
                     </div>
 
                     <div class="leaderboard-content text-sm">

--- a/kernelboard/time.py
+++ b/kernelboard/time.py
@@ -19,12 +19,12 @@ def _to_time_left(deadline: str | datetime, now: datetime) -> str | None:
         d = deadline
 
     if d <= now:
-        return None
+        return 'ended'
         
     delta = d - now
     days = delta.days
     hours = delta.seconds // 3600
-    return f"{days} {"day" if days == 1 else "days"} {hours} {"hour" if hours == 1 else "hours"}"
+    return f"{days} {'day' if days == 1 else 'days'} {hours} {'hour' if hours == 1 else 'hours'} remaining"
 
 
 def format_datetime(dt: datetime | str) -> str:

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -5,18 +5,18 @@ from kernelboard.time import to_time_left, _to_time_left, format_datetime
 def test_to_time_left():
     assert _to_time_left("2025-03-25 12:00:00+00:00", 
                          datetime(2025, 3, 24, 0, 0, 0, tzinfo=timezone.utc)) \
-        == "1 day 12 hours"
+        == "1 day 12 hours remaining"
     assert _to_time_left("2025-03-24 12:00:00+00:00", 
                          datetime(2025, 3, 24, 0, 0, 0, tzinfo=timezone.utc)) \
-        == "0 days 12 hours"
+        == "0 days 12 hours remaining"
     assert _to_time_left("2025-03-26 12:00:00+00:00",
                          datetime(2025, 3, 24, 11, 0, 0, tzinfo=timezone.utc)) \
-        == "2 days 1 hour"
+        == "2 days 1 hour remaining"
     assert _to_time_left(datetime(2025, 3, 25, 12, 0, 0, tzinfo=timezone.utc),
                          datetime(2025, 3, 24, 0, 0, 0, tzinfo=timezone.utc)) \
-        == "1 day 12 hours"
+        == "1 day 12 hours remaining"
     
-    assert to_time_left("1970-01-01 00:00:00+00:00") == None
+    assert to_time_left("1970-01-01 00:00:00+00:00") == "ended"
 
     assert to_time_left("gibberish") == None
 


### PR DESCRIPTION
amd-identity (top-right in the screenshot) shows a leaderboard whose deadline has passed.

![localhost_5000_](https://github.com/user-attachments/assets/c7d87897-1f36-41e7-96af-93af37516b59)
