### PR TITLE
Fix extra code block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ cd frontend && npm run build
 ```
 or at root:
 ```bash
-```
 npm run heroku-postbuild
 ```
 


### PR DESCRIPTION
Extra code block (```) was causing wack formatting in the frontend part of README.md

## Before:

<img width="863" height="494" alt="Screenshot 2025-10-08 at 12 01 03" src="https://github.com/user-attachments/assets/b2269c2e-4ae1-4706-9f79-2d9add6be0dd" />


## After:

<img width="884" height="499" alt="Screenshot 2025-10-08 at 12 01 31" src="https://github.com/user-attachments/assets/dc40cc63-a151-4dc9-bdb2-b0df0e7ad4ba" />

@msaroufim @yangw-dev
