### PR TITLE
update stale teenygrad link

### DIFF
--- a/frontend/src/pages/working-groups/WorkingGroups.tsx
+++ b/frontend/src/pages/working-groups/WorkingGroups.tsx
@@ -94,7 +94,7 @@ const activeProjects: Project[] = [
     name: "Teenygrad",
     description:
       "A teaching deep learning framework: the bridge from micrograd to tinygrad",
-    link: "https://j4orz.ai/sitp/",
+    link: "https://book.j4orz.ai",
   },
   {
     name: "Triton Puzzles",


### PR DESCRIPTION
<img width="725" height="223" alt="Screenshot 2026-01-29 at 7 16 01 AM" src="https://github.com/user-attachments/assets/b3c394f7-cdca-4a08-af69-3c0b77860e3b" />

@msaroufim the book's URL has changed to https://book.j4orz.ai/,
after adding the book's source to the public-facing teenygrad repo.
updating the URL on kernelboard accordingly.

<img width="659" height="111" alt="Screenshot 2026-01-29 at 7 12 03 AM" src="https://github.com/user-attachments/assets/4269d12a-ccd9-4afa-9f30-80dad1d21462" />