### PR TITLE
Remove /v2/ prefix from all routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ If you just want to test the news section without setting up the full database:
    cd frontend && npm install && npm run dev
    ```
 
-5. Open your browser to: `http://localhost:5173/v2/news`
+5. Open your browser to: `http://localhost:5173/news`
 
    You can test direct blog links like:
-   - `http://localhost:5173/v2/news/irl-at-accel`
-   - `http://localhost:5173/v2/news/amd-second-competition`
+   - `http://localhost:5173/news/irl-at-accel`
+   - `http://localhost:5173/news/amd-second-competition`
 
 ### Full Development Setup
 
@@ -178,7 +178,7 @@ The gunicorn server will use port 8000, so visit http://localhost:8000/health
 The React frontend is currently under development. Here's how to run it and view your changes locally.
 
 ### Build for Flask (Static Mode)
-To build the React app and serve it through the Flask backend at `http://localhost:5000/v2/`:
+To build the React app and serve it through the Flask backend at `http://localhost:5000/`:
 
 1. Make changes to your React code.
 2. Run the following command to rebuild the static assets:
@@ -207,7 +207,7 @@ To preview React changes instantly (without rebuilding manually each time):
 cd frontend && npm run dev
 ```
 
-3. Open the React dev server (e.g. `http://localhost:5173/v2/about`) in your browser.
+3. Open the React dev server (e.g. `http://localhost:5173/about`) in your browser.
 
 > In this mode, the React app is served separately with hot-reloading. Use it for faster iteration during development.
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -5,8 +5,8 @@ import App from "./App";
 
 describe("App", () => {
   it("renders the App component", () => {
-    // lead route to /v2/about for unit testing
-    <MemoryRouter initialEntries={["/v2/about"]}>
+    // lead route to /about for unit testing
+    <MemoryRouter initialEntries={["/about"]}>
       render(
       <App />
       );

--- a/frontend/src/components/app-layout/NavBar.test.tsx
+++ b/frontend/src/components/app-layout/NavBar.test.tsx
@@ -11,7 +11,7 @@ describe("NavBar", () => {
     });
 
     expect(workingGroupsLink).toBeInTheDocument();
-    expect(workingGroupsLink).toHaveAttribute("href", "/v2/working-groups");
+    expect(workingGroupsLink).toHaveAttribute("href", "/working-groups");
     // Internal link should not have target="_blank" or rel="noopener"
     expect(workingGroupsLink).not.toHaveAttribute("target", "_blank");
     expect(workingGroupsLink).not.toHaveAttribute("rel", "noopener");

--- a/frontend/src/components/app-layout/NavBar.tsx
+++ b/frontend/src/components/app-layout/NavBar.tsx
@@ -19,8 +19,8 @@ export interface NavLink {
 
 export default function NavBar() {
   const links: NavLink[] = [
-    { label: "News", href: "/v2/news" },
-    { label: "Working Groups", href: "/v2/working-groups" },
+    { label: "News", href: "/news" },
+    { label: "Working Groups", href: "/working-groups" },
     {
       label: "Lectures",
       href: "https://www.youtube.com/@GPUMODE",
@@ -35,7 +35,7 @@ export default function NavBar() {
 
   const Brand = () => (
     <Box sx={brandStyle}>
-      <Link href="/v2/" underline="none" color="inherit">
+      <Link href="/" underline="none" color="inherit">
         <Box sx={{ ...flexRowCenter }}>
           <FlashOnOutlinedIcon sx={flashIconStyle} />
           <Box>GPU MODE</Box>

--- a/frontend/src/components/app-layout/NavUserProfile.tsx
+++ b/frontend/src/components/app-layout/NavUserProfile.tsx
@@ -69,7 +69,7 @@ export default function NavUserProfile() {
     <Tooltip title="Login">
       <Button
         variant="outlined"
-        href={"/v2/login"}
+        href={"/login"}
         size="small"
         sx={styles.loginButoon}
         startIcon={<LoginIcon />}

--- a/frontend/src/pages/login/login.test.tsx
+++ b/frontend/src/pages/login/login.test.tsx
@@ -15,7 +15,7 @@ vi.mock("../../components/alert/AlertBar", () => ({
   ),
 }));
 
-function renderLogin(initialUrl = "/v2/login") {
+function renderLogin(initialUrl = "/login") {
   return render(
     <MemoryRouter initialEntries={[initialUrl]}>
       <Login />
@@ -29,11 +29,11 @@ describe("<Login />", () => {
     const discordBtn = screen.getByRole("link", {
       name: /continue with discord/i,
     });
-    expect(discordBtn).toHaveAttribute("href", "/api/auth/discord?next=/v2/");
+    expect(discordBtn).toHaveAttribute("href", "/api/auth/discord?next=/");
   });
 
   it("shows error when URL has error and message", async () => {
-    renderLogin("/v2/login?error=BadAuth&message=nope");
+    renderLogin("/login?error=BadAuth&message=nope");
     const alert = await screen.findByTestId("alert");
     await waitFor(() => {
       expect(alert).toHaveAttribute("data-open", "true");

--- a/frontend/src/pages/login/login.tsx
+++ b/frontend/src/pages/login/login.tsx
@@ -18,15 +18,15 @@ import AlertBar from "../../components/alert/AlertBar";
 export default function Login() {
   const [params] = useSearchParams();
   const discordLoginUrl = () => {
-    const loginDiscrodHref = `/api/auth/discord?next=/v2/`;
+    const loginDiscrodHref = `/api/auth/discord?next=/`;
     return loginDiscrodHref;
   };
   const googleLoginUrl = () => {
-    const loginGoogleHref = `/api/auth/google?next=/v2/`;
+    const loginGoogleHref = `/api/auth/google?next=/`;
     return loginGoogleHref;
   };
   const githubLoginUrl = () => {
-    const loginGithubHref = `/api/auth/github?next=/v2/`;
+    const loginGithubHref = `/api/auth/github?next=/`;
     return loginGithubHref;
   };
   const error = params.get("error");

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, type UserConfig} from 'vite'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/v2/',
+  base: '/',
   test: {
     environment: 'jsdom',
     globals: true,
@@ -17,7 +17,7 @@ export default defineConfig({
     }
   },
   build: {
-    outDir: path.resolve(__dirname, '../kernelboard/static/v2'),
+    outDir: path.resolve(__dirname, '../kernelboard/static/app'),
     emptyOutDir: true,
   },
   resolve: {

--- a/kernelboard/__init__.py
+++ b/kernelboard/__init__.py
@@ -110,34 +110,29 @@ def create_app(test_config=None):
     app.register_blueprint(health.blueprint)
     app.add_url_rule("/health", endpoint="health")
 
-    @app.route("/")
-    def root():
-        # permanent redirect
-        return redirect("/v2", code=302)
-
     if not app.blueprints.get("api"):
         api = create_api_blueprint()
         app.register_blueprint(api)
 
     @app.errorhandler(401)
     def unauthorized(_error):
-        return redirect("/v2/401")
+        return redirect("/401")
 
     @app.errorhandler(404)
     def not_found(_error):
-        return redirect("/v2/404")
+        return redirect("/404")
 
     @app.errorhandler(500)
     def server_error(_error):
-        return redirect("/v2/500")
+        return redirect("/500")
 
-    # Route for serving React frontend from the /v2/ path
-    # # This handles both the base path `/v2/` and any subpath `/v2/<path>`
-    @app.route("/v2/", defaults={"path": ""})
-    @app.route("/v2/<path:path>")
+    # Route for serving React frontend from root path
+    # This handles both the base path `/` and any subpath `/<path>`
+    @app.route("/", defaults={"path": ""})
+    @app.route("/<path:path>")
     def serve_react(path):
         # set the react static binary path
-        static_dir = os.path.join(app.static_folder, "v2")
+        static_dir = os.path.join(app.static_folder, "app")
         full_path = os.path.join(static_dir, path)
 
         if path != "" and os.path.exists(full_path):

--- a/kernelboard/api/auth.py
+++ b/kernelboard/api/auth.py
@@ -38,7 +38,7 @@ def redirect_with_error(error: str, message: str = ""):
     q = {"error": _sanitize(error)}
     if message:
         q["message"] = _sanitize(message)
-    return redirect(f"/v2/login?{urlencode(q)}")
+    return redirect(f"/login?{urlencode(q)}")
 
 
 def _error_params_from_provider(args) -> dict[str, str]:
@@ -148,15 +148,15 @@ def _get_avatar_url_from_provider(provider: str, identity: str, data: dict) -> s
 def auth(provider: str):
     """
     Start OAuth2 login by redirecting to the provider's authorization URL.
-    Optional ?next=/v2/some/page to return the user after login.
+    Optional ?next=/some/page to return the user after login.
     """
     if not current_user.is_anonymous:
         print("current_user found")
-        return redirect("/v2/")
+        return redirect("/")
 
     provider_data = app.config["OAUTH2_PROVIDERS"].get(provider)
     if not provider_data:
-        return redirect("/v2/404")
+        return redirect("/404")
 
     # Save CSRF state (and optional next) in session
     state = secrets.token_urlsafe(16)
@@ -188,12 +188,12 @@ def callback(provider: str):
     stores display fields in session, logs the user in, and redirects to the SPA.
     """
     if not current_user.is_anonymous:
-        return redirect("/v2/")
+        return redirect("/")
 
 
     provider_data = app.config["OAUTH2_PROVIDERS"].get(provider)
     if not provider_data:
-        return redirect("/v2/login?error=invalid_provider")
+        return redirect("/login?error=invalid_provider")
 
     # Handle provider error short-circuit
     if any(k in _ALLOWED_ERROR_KEYS for k in request.args):
@@ -208,7 +208,7 @@ def callback(provider: str):
         app.logger.info(
             "OAuth provider error: %s", safe
         )  # log sanitized version
-        return redirect(f"/v2/login?{urlencode(safe)}")
+        return redirect(f"/login?{urlencode(safe)}")
 
     # Validate state and presence of code
     if request.args.get("state") != session.get("oauth2_state"):
@@ -306,7 +306,7 @@ def callback(provider: str):
     # 6) Clean up and redirec
     next_url = session.pop("oauth2_next", None)
     session.pop("oauth2_state", None)
-    return redirect(next_url or "/v2/")
+    return redirect(next_url or "/")
 
 
 @auth_bp.get("/logout")

--- a/kernelboard/lib/frontend_redirect.py
+++ b/kernelboard/lib/frontend_redirect.py
@@ -1,5 +1,5 @@
 
-FRONTEND_ORIGIN = os.getenv("FRONTEND_ORIGIN", "/v2/")  # e.g. "/", "/v2/", or "https://app.example.com"
+FRONTEND_ORIGIN = os.getenv("FRONTEND_ORIGIN", "/")  # e.g. "/", or "https://app.example.com"
 
 def _is_safe_path(p: str) -> bool:
     """Allow only same-origin paths (no scheme/netloc)."""

--- a/tests/api/test_auth_api.py
+++ b/tests/api/test_auth_api.py
@@ -21,12 +21,12 @@ def test_auth_already_logged_in(client):
 
     response = client.get("/api/auth/discord")
     assert response.status_code == 302
-    assert response.headers.get("Location") == "/v2/"
+    assert response.headers.get("Location") == "/"
 
 
 def test_auth_unknown_provider(client):
     response = client.get("/api/auth/unknown_provider")
-    assert response.headers.get("Location") == "/v2/404"
+    assert response.headers.get("Location") == "/404"
 
 
 def test_callback_already_logged_in(client):
@@ -35,13 +35,13 @@ def test_callback_already_logged_in(client):
 
     response = client.get("/api/auth/discord/callback")
     assert response.status_code == 302
-    assert response.headers.get("Location") == "/v2/"
+    assert response.headers.get("Location") == "/"
 
 
 def test_callback_unknown_provider(client):
     response = client.get("/api/auth/unknown_provider/callback")
     location = response.headers.get("Location")
-    assert "/v2/login?error=invalid_provider" in location
+    assert "/login?error=invalid_provider" in location
 
 
 def test_callback_mismatched_state(client):
@@ -153,7 +153,7 @@ def test_callback_happy_path(client):
                 "api/auth/discord/callback?state=123&code=456"
             )
             assert response.status_code == 302
-            assert response.headers.get("Location") == "/v2/"
+            assert response.headers.get("Location") == "/"
 
 
 def test_logout(client):
@@ -165,7 +165,7 @@ def assert_redirect_with_error(
     response, expected_error: str, expected_message: str | None = None
 ):
     """
-    Assert that a response redirected to /v2/login with given error and optional message.
+    Assert that a response redirected to /login with given error and optional message.
     """
     location = response.headers.get("Location")
     assert location, "Response has no Location header"
@@ -174,7 +174,7 @@ def assert_redirect_with_error(
     qs = parse_qs(parsed.query)
 
     # path check
-    assert parsed.path == "/v2/login"
+    assert parsed.path == "/login"
 
     # error code check
     assert qs.get("error") == [expected_error]


### PR DESCRIPTION
The site now serves directly from / instead of /v2/:
- / instead of /v2/
- /news instead of /v2/news
- /login instead of /v2/login
- /working-groups instead of /v2/working-groups

Updated Vite config, Flask routes, OAuth redirects, frontend navigation links, and all related tests.