### PR TITLE
Make logo responsive on mobile

### DIFF
--- a/frontend/src/components/app-layout/NavBar.tsx
+++ b/frontend/src/components/app-layout/NavBar.tsx
@@ -32,10 +32,14 @@ export default function NavBar() {
     <Box sx={brandStyle}>
       <Link href="/" underline="none" color="inherit">
         <Box sx={{ ...flexRowCenter }}>
-          <img
+          <Box
+            component="img"
             src="/gpu-mode-logo/black-cropped.svg"
             alt="GPU MODE"
-            style={{ height: 32 }}
+            sx={{
+              height: { xs: 24, sm: 32 },
+              maxWidth: "100%",
+            }}
           />
         </Box>
       </Link>


### PR DESCRIPTION
## Summary
- Use responsive height for logo: 24px on mobile (xs), 32px on larger screens (sm+)
- Add maxWidth: 100% to prevent clipping on narrow viewports

## Test plan
- [ ] Verify full logo is visible on mobile without clipping
- [ ] Verify logo displays at correct size on desktop