### PR TITLE
Fix grey background on code lines in leaderboard

### DIFF
--- a/frontend/src/components/codeblock/CodeBlock.tsx
+++ b/frontend/src/components/codeblock/CodeBlock.tsx
@@ -69,6 +69,9 @@ export default function CodeBlock({ code }: CodeBlockProps) {
             fontFamily: "monospace !important",
             background: "transparent !important",
           },
+          "& code": {
+            background: "transparent !important",
+          },
         }}
       >
         <SyntaxHighlighter


### PR DESCRIPTION
## Summary
- Removes the per-line grey background on code snippets in the leaderboard view
- The Prism syntax highlighter theme applies a background color to each `<code>` element, causing individual grey boxes behind every line of code
- Adds a `& code { background: transparent }` override, matching the existing `& pre` override

## Test plan
- [ ] Open a leaderboard entry with a code snippet
- [ ] Verify code lines no longer have individual grey backgrounds
- [ ] Verify syntax highlighting still works correctly in both light and dark mode