### PR TITLE
Add admin submission view and delete from rankings

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -216,6 +216,17 @@ export async function submitFile(form: FormData) {
   return data; // e.g. { submission_id, message, ... }
 }
 
+export async function deleteSubmission(submissionId: number): Promise<void> {
+  const res = await fetch(`/api/submission/${submissionId}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const json = await res.json();
+    const message = json?.message || "Failed to delete submission";
+    throw new APIError(message, res.status);
+  }
+}
+
 export async function fetchUserSubmissions(
   leaderboardId: number | string,
   userId: number | string,

--- a/frontend/src/pages/leaderboard/Leaderboard.tsx
+++ b/frontend/src/pages/leaderboard/Leaderboard.tsx
@@ -191,22 +191,26 @@ export default function Leaderboard() {
         <Grid marginBottom={2}>
           <Card>
             <CardContent>
-              <CardTitle fontWeight="bold">Description</CardTitle>
-              <MarkdownRenderer content={data.description} />
-              {data.benchmarks && data.benchmarks.length > 0 && (
-                <details>
-                  <summary style={{ cursor: "pointer", fontWeight: "bold", marginTop: 16 }}>
-                    Benchmark Shapes
-                  </summary>
-                  <ul>
-                    {data.benchmarks.map((b, i) => (
-                      <li key={i}>
-                        <code>{JSON.stringify(Object.fromEntries(Object.entries(b).filter(([k]) => k !== "seed")))}</code>
-                      </li>
-                    ))}
-                  </ul>
-                </details>
-              )}
+              <details>
+                <summary style={{ cursor: "pointer", fontWeight: "bold", fontSize: "1.5rem" }}>
+                  Description
+                </summary>
+                <MarkdownRenderer content={data.description} />
+                {data.benchmarks && data.benchmarks.length > 0 && (
+                  <details>
+                    <summary style={{ cursor: "pointer", fontWeight: "bold", marginTop: 16 }}>
+                      Benchmark Shapes
+                    </summary>
+                    <ul>
+                      {data.benchmarks.map((b, i) => (
+                        <li key={i}>
+                          <code>{JSON.stringify(Object.fromEntries(Object.entries(b).filter(([k]) => k !== "seed")))}</code>
+                        </li>
+                      ))}
+                    </ul>
+                  </details>
+                )}
+              </details>
             </CardContent>
           </Card>
         </Grid>

--- a/frontend/src/pages/leaderboard/Leaderboard.tsx
+++ b/frontend/src/pages/leaderboard/Leaderboard.tsx
@@ -240,6 +240,9 @@ export default function Leaderboard() {
                   rankings={data.rankings}
                   leaderboardId={id}
                   deadline={data.deadline}
+                  onRefresh={() => {
+                    if (id) call(id);
+                  }}
                 />
                 <Box sx={{ my: 4, borderTop: 1, borderColor: "divider" }} />
                 <Card>

--- a/kernelboard/lib/env.py
+++ b/kernelboard/lib/env.py
@@ -23,6 +23,7 @@ def check_env_vars():
         "DISCORD_CLIENT_ID": "preview-disabled",
         "DISCORD_CLIENT_SECRET": "preview-disabled",
         "DISCORD_CLUSTER_MANAGER_API_BASE_URL": "http://localhost:8080",
+        "ADMIN_TOKEN": "",
     }
 
     for var, default in optional_with_defaults.items():


### PR DESCRIPTION
## Summary
- Admins can click submission IDs in the rankings list to open a dialog showing the submitted code
- Dialog includes a two-step delete confirmation (Delete → Confirm Delete)
- Backend proxies delete to kernelbot's existing `DELETE /admin/submissions/{id}` endpoint using `ADMIN_TOKEN` (Bearer auth)
- Leaderboard auto-refreshes after successful deletion

## Changes
- **Backend** (`kernelboard/api/submission.py`): New `DELETE /api/submission/<id>` with admin whitelist check + proxy to kernelbot
- **Backend** (`kernelboard/lib/env.py`): Register `ADMIN_TOKEN` as optional env var
- **Frontend API** (`api.ts`): New `deleteSubmission()` function
- **Frontend UI** (`RankingLists.tsx`): Clickable submission ID → dialog with CodeBlock + delete flow
- **Parent wiring** (`Leaderboard.tsx`): Passes `onRefresh` callback to re-fetch rankings after delete

## No kernelbot changes needed
Kernelbot already has `DELETE /admin/submissions/{id}` with Bearer token auth. Kernelboard just needs the same `ADMIN_TOKEN` env var to call it.

## Deployment
Set `ADMIN_TOKEN` env var on kernelboard (same value as kernelbot's `ADMIN_TOKEN`).

## Test plan
- [ ] As admin: click submission ID, verify code renders in dialog
- [ ] Click Delete → verify confirmation step appears
- [ ] Confirm delete → verify submission removed and rankings refresh
- [ ] As non-admin: verify submission IDs are not clickable (not visible)
- [ ] Verify non-admin API calls return 403