### PR TITLE
Fix beginner problem classification

### DIFF
--- a/frontend/src/pages/home/Home.test.tsx
+++ b/frontend/src/pages/home/Home.test.tsx
@@ -422,6 +422,69 @@ describe("Home", () => {
     expect(screen.getByText("expired-private-competition")).toBeInTheDocument();
   });
 
+  it("does not classify every v2 leaderboard as a beginner problem", () => {
+    const mockData = {
+      leaderboards: [
+        {
+          id: 1,
+          name: "grayscale_v2",
+          deadline: "2027-12-31T23:59:59Z",
+          gpu_types: ["T4"],
+          priority_gpu_type: "T4",
+          top_users: null,
+        },
+        {
+          id: 2,
+          name: "qr_v2",
+          deadline: "2027-12-31T23:59:59Z",
+          gpu_types: ["B200"],
+          priority_gpu_type: "B200",
+          top_users: null,
+        },
+      ],
+      now: "2025-01-01T00:00:00Z",
+    };
+
+    const mockHookReturn = {
+      data: mockData,
+      loading: false,
+      hasLoaded: true,
+      error: null,
+      errorStatus: null,
+      call: mockCall,
+    };
+
+    (apiHook.fetcherApiCallback as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockHookReturn,
+    );
+
+    renderWithProviders(<Home />);
+
+    const activeHeading = screen.getByText("Active Competitions");
+    const gettingStartedHeading = screen.getByText("Getting Started");
+    const qrTile = screen.getByText("qr_v2");
+    const grayscaleTile = screen.getByText("grayscale_v2");
+
+    expect(
+      Boolean(
+        activeHeading.compareDocumentPosition(qrTile) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
+    expect(
+      Boolean(
+        qrTile.compareDocumentPosition(gettingStartedHeading) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
+    expect(
+      Boolean(
+        gettingStartedHeading.compareDocumentPosition(grayscaleTile) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
+  });
+
   describe("LeaderboardTile functionality", () => {
     it("displays time left correctly", () => {
       const mockData = {

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -48,8 +48,19 @@ interface LeaderboardSummaries {
   now: string;
 }
 
+const BEGINNER_PROBLEM_NAMES = new Set([
+  "conv2d_v2",
+  "grayscale_v2",
+  "histogram_v2",
+  "matmul_v2",
+  "prefixsum_v2",
+  "sort_v2",
+  "vectoradd_v2",
+  "vectorsum_v2",
+]);
+
 function isBeginnerProblem(name: string): boolean {
-  return /_v2\b/i.test(name);
+  return BEGINNER_PROBLEM_NAMES.has(name.toLowerCase());
 }
 
 export default function Home() {


### PR DESCRIPTION
## Summary
- replace the `_v2` suffix heuristic with an explicit PMPP beginner problem allowlist
- add a regression test that keeps `qr_v2` in Active Competitions while `grayscale_v2` remains in Getting Started

## Validation
- `npm test -- Home.test.tsx --run`
