### PR TITLE
Require secret leaderboard pass for public rankings

### DIFF
--- a/kernelboard/api/leaderboard.py
+++ b/kernelboard/api/leaderboard.py
@@ -170,6 +170,15 @@ def _get_query():
                 AND r.score IS NOT NULL
                 AND r.passed
                 AND s.leaderboard_id = %(leaderboard_id)s
+                AND EXISTS (
+                    SELECT 1
+                    FROM leaderboard.runs sr
+                    WHERE sr.submission_id = s.id
+                        AND sr.secret
+                        AND sr.runner = r.runner
+                        AND sr.mode = 'leaderboard'
+                        AND sr.passed
+                )
                 AND NOT EXISTS (
                     SELECT 1
                     FROM leaderboard.runs sr
@@ -259,6 +268,15 @@ def get_custom_trend(leaderboard_id: int):
               AND r.score IS NOT NULL
               AND r.passed = true
               AND NOT r.secret
+              AND EXISTS (
+                  SELECT 1
+                  FROM leaderboard.runs sr
+                  WHERE sr.submission_id = s.id
+                    AND sr.secret
+                    AND sr.runner = r.runner
+                    AND sr.mode = 'leaderboard'
+                    AND sr.passed
+              )
               AND NOT EXISTS (
                   SELECT 1
                   FROM leaderboard.runs sr
@@ -388,6 +406,15 @@ def get_user_trend(leaderboard_id: int):
               AND r.score IS NOT NULL
               AND r.passed = true
               AND NOT r.secret
+              AND EXISTS (
+                  SELECT 1
+                  FROM leaderboard.runs sr
+                  WHERE sr.submission_id = s.id
+                    AND sr.secret
+                    AND sr.runner = r.runner
+                    AND sr.mode = 'leaderboard'
+                    AND sr.passed
+              )
               AND NOT EXISTS (
                   SELECT 1
                   FROM leaderboard.runs sr
@@ -482,6 +509,15 @@ def get_fastest_trend(leaderboard_id: int):
               AND r.score IS NOT NULL
               AND r.passed = true
               AND NOT r.secret
+              AND EXISTS (
+                  SELECT 1
+                  FROM leaderboard.runs sr
+                  WHERE sr.submission_id = s.id
+                    AND sr.secret
+                    AND sr.runner = r.runner
+                    AND sr.mode = 'leaderboard'
+                    AND sr.passed
+              )
               AND NOT EXISTS (
                   SELECT 1
                   FROM leaderboard.runs sr

--- a/kernelboard/api/leaderboard_summaries.py
+++ b/kernelboard/api/leaderboard_summaries.py
@@ -370,6 +370,15 @@ def _get_query_for_ids():
                 AND r.score IS NOT NULL
                 AND r.passed
                 AND s.leaderboard_id IN %s
+                AND EXISTS (
+                    SELECT 1
+                    FROM leaderboard.runs sr
+                    WHERE sr.submission_id = s.id
+                        AND sr.secret
+                        AND sr.runner = r.runner
+                        AND sr.mode = 'leaderboard'
+                        AND sr.passed
+                )
                 AND NOT EXISTS (
                     SELECT 1
                     FROM leaderboard.runs sr
@@ -474,6 +483,15 @@ def _get_query():
             WHERE NOT r.secret
                 AND r.score IS NOT NULL
                 AND r.passed
+                AND EXISTS (
+                    SELECT 1
+                    FROM leaderboard.runs sr
+                    WHERE sr.submission_id = s.id
+                        AND sr.secret
+                        AND sr.runner = r.runner
+                        AND sr.mode = 'leaderboard'
+                        AND sr.passed
+                )
                 AND NOT EXISTS (
                     SELECT 1
                     FROM leaderboard.runs sr

--- a/kernelboard/index.py
+++ b/kernelboard/index.py
@@ -86,6 +86,15 @@ def index():
             WHERE NOT r.secret
                 AND r.score IS NOT NULL
                 AND r.passed
+                AND EXISTS (
+                    SELECT 1
+                    FROM leaderboard.runs sr
+                    WHERE sr.submission_id = s.id
+                        AND sr.secret
+                        AND sr.runner = r.runner
+                        AND sr.mode = 'leaderboard'
+                        AND sr.passed
+                )
                 AND NOT EXISTS (
                     SELECT 1
                     FROM leaderboard.runs sr

--- a/kernelboard/leaderboard.py
+++ b/kernelboard/leaderboard.py
@@ -46,6 +46,15 @@ def leaderboard(leaderboard_id: int):
                 AND r.score IS NOT NULL
                 AND r.passed
                 AND s.leaderboard_id = %(leaderboard_id)s
+                AND EXISTS (
+                    SELECT 1
+                    FROM leaderboard.runs sr
+                    WHERE sr.submission_id = s.id
+                        AND sr.secret
+                        AND sr.runner = r.runner
+                        AND sr.mode = 'leaderboard'
+                        AND sr.passed
+                )
                 AND NOT EXISTS (
                     SELECT 1
                     FROM leaderboard.runs sr

--- a/ranking_worker.py
+++ b/ranking_worker.py
@@ -130,6 +130,15 @@ personal_best_candidates AS (
     WHERE NOT r.secret
         AND r.score IS NOT NULL
         AND r.passed
+        AND EXISTS (
+            SELECT 1
+            FROM leaderboard.runs sr
+            WHERE sr.submission_id = s.id
+                AND sr.secret
+                AND sr.runner = r.runner
+                AND sr.mode = 'leaderboard'
+                AND sr.passed
+        )
         AND NOT EXISTS (
             SELECT 1
             FROM leaderboard.runs sr

--- a/tests/api/test_leaderboard_api.py
+++ b/tests/api/test_leaderboard_api.py
@@ -38,7 +38,8 @@ def test_failed_secret_benchmark_hides_public_leaderboard_run(client, app):
                     (id, leaderboard_id, file_name, user_id, code_id, submission_time, done)
                 VALUES
                     (900001, 339, 'hidden_secret_fail.py', '123456789012345', 13, NOW(), TRUE),
-                    (900002, 339, 'visible_public_pass.py', '234567890123456', 13, NOW(), TRUE)
+                    (900002, 339, 'visible_public_pass.py', '234567890123456', 13, NOW(), TRUE),
+                    (900003, 339, 'hidden_missing_secret.py', '345678901234567', 13, NOW(), TRUE)
                 """
             )
             cur.execute(
@@ -104,6 +105,36 @@ def test_failed_secret_benchmark_hides_public_leaderboard_run(client, app):
                         '{}',
                         '{}',
                         '{}'
+                    ),
+                    (
+                        900004,
+                        900002,
+                        NOW(),
+                        NOW(),
+                        'leaderboard',
+                        TRUE,
+                        'H100',
+                        -998,
+                        TRUE,
+                        '{}',
+                        '{}',
+                        '{}',
+                        '{}'
+                    ),
+                    (
+                        900005,
+                        900003,
+                        NOW(),
+                        NOW(),
+                        'leaderboard',
+                        FALSE,
+                        'H100',
+                        -997,
+                        TRUE,
+                        '{}',
+                        '{}',
+                        '{}',
+                        '{}'
                     )
                 """
             )
@@ -117,4 +148,5 @@ def test_failed_secret_benchmark_hides_public_leaderboard_run(client, app):
     ranked_files = {row["file_name"] for row in h100_rankings}
 
     assert "hidden_secret_fail.py" not in ranked_files
+    assert "hidden_missing_secret.py" not in ranked_files
     assert "visible_public_pass.py" in ranked_files

--- a/tests/data.sql
+++ b/tests/data.sql
@@ -80,7 +80,8 @@ CREATE TABLE leaderboard.leaderboard (
     creator_id bigint DEFAULT '-1'::integer NOT NULL,
     forum_id bigint NOT NULL,
     secret_seed bigint DEFAULT floor((random() * ('2147483648'::bigint)::double precision)) NOT NULL,
-    description text NOT NULL
+    description text NOT NULL,
+    visibility text DEFAULT 'public'::text NOT NULL
 );
 
 


### PR DESCRIPTION
## Summary

- Require a matching passed secret `leaderboard` run on the same submission and runner before public scores appear in ranking APIs, summaries, trend endpoints, rendered leaderboard SQL, and ranking notifications.
- Add API regression coverage for public scores that pass publicly but have no secret leaderboard validation.
- Update the local test DB fixture to include the existing app-expected `leaderboard.visibility` column.

## Testing

- `DOCKER_CONFIG=/tmp/docker-config-anon REDIS_URL=redis://localhost:6380/0 uv run --with-requirements requirements.txt pytest -q tests/api/test_leaderboard_api.py`
  - `4 passed`
- `DOCKER_CONFIG=/tmp/docker-config-anon REDIS_URL=redis://localhost:6380/0 uv run --with-requirements requirements.txt pytest -q tests/api/test_leaderboard_summaries_api.py`
  - `2 passed`
- `git diff --check`

## Note

Legacy rendered-page tests under `tests/test_leaderboard.py` and `tests/test_index.py` still fail locally with `302 -> /404`; this appears unrelated to the ranking SQL changes.