### PR TITLE
Add Rohan Anil to admin whitelist

### DIFF
--- a/kernelboard/lib/auth_utils.py
+++ b/kernelboard/lib/auth_utils.py
@@ -116,6 +116,7 @@ def get_whitelist(leaderboard_id: str = "") -> set[str]:
         "1394757548833509408",
         "268205958637944832",
         "1354693822055055441",
+        "17482230",  # rohan-anil GitHub user id
     ]
 
     whitelist = GPU_TEAM_WHITE_LIST


### PR DESCRIPTION
## Summary\n- Add Rohan Anil's GitHub numeric user id to the kernelboard admin whitelist so he can view submission code when logged in via GitHub.\n\n## Test\n- python3 -m py_compile kernelboard/lib/auth_utils.py