### PR TITLE
Make admin whitelist provider-aware

### DIFF
--- a/kernelboard/api/leaderboard_summaries.py
+++ b/kernelboard/api/leaderboard_summaries.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 from flask import Blueprint, request
 
-from kernelboard.lib.auth_utils import get_id_and_username_from_session, get_whitelist
+from kernelboard.lib.auth_utils import is_current_user_admin
 from kernelboard.lib.db import get_db_connection
 from kernelboard.lib.redis_connection import get_redis_connection
 from kernelboard.lib.status_code import http_success
@@ -91,9 +91,7 @@ def index():
     force_refresh = request.args.get("force_refresh_cache") is not None
 
     # Check if user is admin to force refresh cache
-    user_id, _ = get_id_and_username_from_session()
-    whitelist = get_whitelist()
-    if not user_id or user_id not in whitelist:
+    if not is_current_user_admin():
         logger.info("[leaderboard_summaries] skip force_refresh since user is not admin")
         force_refresh = False
 

--- a/kernelboard/api/submission.py
+++ b/kernelboard/api/submission.py
@@ -13,7 +13,7 @@ from flask_login import current_user, login_required
 
 from kernelboard.lib.auth_utils import (
     get_id_and_username_from_session,
-    get_whitelist,
+    is_current_user_admin,
 )
 from kernelboard.lib.db import get_db_connection
 from kernelboard.lib.error import ValidationError, validate_required_fields
@@ -202,7 +202,7 @@ def list_codes_route():
         else:
             # otherwise, check if user able to see the leaderboard codes
             # (only admin can see the leaderboard codes if leaderboard is not ended)
-            return check_admin_access_codes(user_id, leaderboard_id, submission_ids)
+            return check_admin_access_codes(leaderboard_id, submission_ids)
     except Exception as e:
         logger.error(f"faild to list codes: {e}")
         return http_error(
@@ -211,12 +211,9 @@ def list_codes_route():
         )
 
 
-def check_admin_access_codes(
-    user_id: str, leaderboard_id: int, submission_ids: List[int]
-):
+def check_admin_access_codes(leaderboard_id: int, submission_ids: List[int]):
     # check if user able to see the leaderboard codes
-    whilte_list = get_whitelist(leaderboard_id)
-    if user_id not in whilte_list:
+    if not is_current_user_admin(str(leaderboard_id)):
         logger.info("[list_codes] user is not admin, skip the request")
         return http_success(message="skip since user is not admin", data={})
     else:

--- a/kernelboard/lib/auth_utils.py
+++ b/kernelboard/lib/auth_utils.py
@@ -34,7 +34,7 @@ def get_user_info_from_session() -> Any:
             "identity": identity,
             "display_name": session.get("display_name") if is_auth else None,
             "avatar_url": session.get("avatar_url") if is_auth else None,
-            "is_admin": identity in get_whitelist() if is_auth and identity else False,
+            "is_admin": is_admin_identity(provider, identity) if is_auth else False,
         },
     }
     return res
@@ -98,28 +98,44 @@ def ensure_user_info_with_token(user_id: int, user_name: str) -> Optional[Any]:
         return cur.fetchone()
 
 
-def get_whitelist(leaderboard_id: str = "") -> set[str]:
+def get_whitelist(leaderboard_id: str = "") -> set[tuple[str, str]]:
     """
-     return a unique set of cleaned Discord user IDs.
+    Return a unique set of whitelisted (provider, identity) pairs.
     TODO: move this to a db table if more roles are needed
     """
     if not isinstance(leaderboard_id, str):
         leaderboard_id = str(leaderboard_id)
 
     # GpuMode CORE Team, always have access to all leaderboards
-    GPU_TEAM_WHITE_LIST = [
-        "1372260358621888674",
-        "489144435032981515",
-        "838132355075014667",
-        "325883680419610631",
-        "557943190045327360",
-        "1394757548833509408",
-        "268205958637944832",
-        "1354693822055055441",
-        "17482230",  # rohan-anil GitHub user id
-    ]
+    GPU_TEAM_ADMINS = {
+        ("discord", "1372260358621888674"): "elainewy",
+        ("discord", "489144435032981515"): "siro",
+        ("discord", "838132355075014667"): "Erik S.",
+        ("discord", "325883680419610631"): "Seraphim",
+        ("discord", "557943190045327360"): "Snektron",
+        ("discord", "1394757548833509408"): "Emre",
+        ("discord", "268205958637944832"): "az",
+        ("github", "17482230"): "rohan-anil",
+    }
 
-    whitelist = GPU_TEAM_WHITE_LIST
+    whitelist = GPU_TEAM_ADMINS.keys()
 
     # Add leaderboard based white_list,notice leaderboard_id is a string
     return set(whitelist)
+
+
+def is_admin_identity(
+    provider: Optional[str],
+    identity: Optional[str],
+    leaderboard_id: str = "",
+) -> bool:
+    if not provider or not identity:
+        return False
+    return (provider, identity) in get_whitelist(leaderboard_id)
+
+
+def is_current_user_admin(leaderboard_id: str = "") -> bool:
+    if current_user.is_anonymous:
+        return False
+    d = get_provider_and_identity(current_user.get_id())
+    return is_admin_identity(d["provider"], d["identity"], leaderboard_id)


### PR DESCRIPTION
## Summary\n- Store admin whitelist entries as explicit provider/identity pairs.\n- Update admin checks to compare  instead of identity-only strings.\n- Remove Daniel Huang from the admin whitelist.\n\n## Test\n- python3 -m py_compile kernelboard/lib/auth_utils.py kernelboard/api/submission.py kernelboard/api/leaderboard_summaries.py