### PR TITLE
Add homepage sponsor callout

### DIFF
--- a/frontend/src/pages/home/Home.test.tsx
+++ b/frontend/src/pages/home/Home.test.tsx
@@ -149,6 +149,15 @@ describe("Home", () => {
     renderWithProviders(<Home />);
 
     expect(screen.getByText("Leaderboards")).toBeInTheDocument();
+    expect(
+      screen.getByText(/GPU MODE's mission is to make high-performance/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Core Automation/i)).toBeInTheDocument();
+    expect(screen.getByText(/Northflank/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /reach out/i })).toHaveAttribute(
+      "href",
+      "mailto:mark@gpumode.com",
+    );
     expect(screen.getByText("test-leaderboard")).toBeInTheDocument();
     expect(screen.getByText("T4, L4")).toBeInTheDocument();
     expect(screen.getByText("alice")).toBeInTheDocument();

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -122,6 +122,41 @@ export default function Home() {
   return (
     <ConstrainedContainer>
       <Box>
+        <Box
+          sx={{
+            border: 1,
+            borderColor: "divider",
+            borderRadius: 1,
+            bgcolor: "background.paper",
+            px: 2,
+            py: 1.5,
+            width: "100%",
+            mb: 3,
+          }}
+        >
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ lineHeight: 1.6 }}
+          >
+            GPU MODE&apos;s mission is to make high-performance GPU programming
+            more accessible.
+            <br />
+            We rely on donations and sponsorships to fund community compute,
+            lectures, kernel competitions, working groups, and events.
+            <br />
+            Thank you to Modal, Core Automation, and Northflank for supporting
+            us. To sponsor GPU MODE, please{" "}
+            <Box
+              component="a"
+              href="mailto:mark@gpumode.com"
+              sx={{ color: "primary.main", fontWeight: 600 }}
+            >
+              reach out
+            </Box>
+            .
+          </Typography>
+        </Box>
         <Typography variant="h1" component="h1" sx={{ mb: 3 }}>
           Leaderboards
         </Typography>

--- a/frontend/src/pages/lectures/Lectures.tsx
+++ b/frontend/src/pages/lectures/Lectures.tsx
@@ -1,7 +1,8 @@
 import { Box, Typography, Link, Chip } from "@mui/material";
 import type { Theme } from "@mui/material/styles";
 import { useEffect, useState } from "react";
-import { fetchEvents, DiscordEvent } from "../../api/api";
+import { fetchEvents } from "../../api/api";
+import type { DiscordEvent } from "../../api/api";
 import Loading from "../../components/common/loading";
 
 const styles = {

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -2,6 +2,20 @@ import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
 // runs a clean after each test case (e.g. clearing jsdom)
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Summary
- Add a full-width bordered sponsor/funding callout above the homepage Leaderboards heading.
- Thank Modal, Core Automation, and Northflank, and link "reach out" to mark@gpumode.com.
- Fix the Lectures page `DiscordEvent` import to be type-only so the dev app can mount cleanly.
- Add a `matchMedia` test setup stub used by the theme store in jsdom.

## Validation
- `npm test -- Home.test.tsx --run -t "shows leaderboards when data is loaded"`
- `npm run build`
