### PR TITLE
Show LOC for public solutions

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -43,6 +43,7 @@ export interface CodesResponse {
   results: Array<{
     submission_id: number;
     code: string;
+    line_count?: number;
   }>;
 }
 

--- a/frontend/src/pages/leaderboard/Leaderboard.tsx
+++ b/frontend/src/pages/leaderboard/Leaderboard.tsx
@@ -417,6 +417,7 @@ function LeaderboardWithSidebar() {
     navigationItems,
     navigationIndex,
     codes,
+    lineCounts,
     isOpen,
     isLoadingCodes,
     navigate,
@@ -455,6 +456,7 @@ function LeaderboardWithSidebar() {
         navigationItems={navigationItems}
         navigationIndex={navigationIndex}
         codes={codes}
+        lineCounts={lineCounts}
         isLoadingCodes={isLoadingCodes}
         onClose={close}
         onNavigate={navigate}

--- a/frontend/src/pages/leaderboard/components/SubmissionCodeSidebar.test.tsx
+++ b/frontend/src/pages/leaderboard/components/SubmissionCodeSidebar.test.tsx
@@ -1,0 +1,48 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "../../../tests/test-utils";
+import SubmissionCodeSidebar from "./SubmissionCodeSidebar";
+
+describe("SubmissionCodeSidebar", () => {
+  it("shows LOC when line count metadata is available", () => {
+    renderWithProviders(
+      <SubmissionCodeSidebar
+        selectedSubmission={{
+          submissionId: 123,
+          userName: "alice",
+          fileName: "solution.py",
+          score: 12.5,
+        }}
+        navigationItems={[]}
+        navigationIndex={0}
+        codes={new Map([[123, "print('hello')\nprint('world')\n"]])}
+        lineCounts={new Map([[123, 2]])}
+        onClose={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("LOC")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("does not show LOC without line count metadata", () => {
+    renderWithProviders(
+      <SubmissionCodeSidebar
+        selectedSubmission={{
+          submissionId: 123,
+          userName: "alice",
+          fileName: "solution.py",
+          score: 12.5,
+        }}
+        navigationItems={[]}
+        navigationIndex={0}
+        codes={new Map([[123, "print('hello')\n"]])}
+        onClose={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("LOC")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/leaderboard/components/SubmissionCodeSidebar.tsx
+++ b/frontend/src/pages/leaderboard/components/SubmissionCodeSidebar.tsx
@@ -22,6 +22,7 @@ interface SubmissionCodeSidebarProps {
   navigationItems: NavigationItem[];
   navigationIndex: number;
   codes: Map<number, string>;
+  lineCounts?: Map<number, number>;
   isLoadingCodes?: boolean;
   onClose: () => void;
   onNavigate: (newIndex: number, item: NavigationItem) => void;
@@ -34,6 +35,7 @@ export default function SubmissionCodeSidebar({
   navigationItems,
   navigationIndex,
   codes,
+  lineCounts,
   isLoadingCodes = false,
   onClose,
   onNavigate,
@@ -91,6 +93,9 @@ export default function SubmissionCodeSidebar({
   }, [onWidthChange]);
 
   const drawerWidth = isMobile ? "100vw" : width;
+  const lineCount = selectedSubmission
+    ? lineCounts?.get(selectedSubmission.submissionId)
+    : undefined;
 
   return (
     <Drawer
@@ -194,7 +199,8 @@ export default function SubmissionCodeSidebar({
             {/* Metadata */}
             {(selectedSubmission.timestamp ||
               selectedSubmission.originalTimestamp ||
-              selectedSubmission.score !== undefined) && (
+              selectedSubmission.score !== undefined ||
+              lineCount !== undefined) && (
               <Box
                 sx={{
                   px: 2,
@@ -253,6 +259,20 @@ export default function SubmissionCodeSidebar({
                       </Typography>
                       <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
                         {formatMicroseconds(selectedSubmission.score)}
+                      </Typography>
+                    </Box>
+                  )}
+                  {lineCount !== undefined && (
+                    <Box>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        display="block"
+                      >
+                        LOC
+                      </Typography>
+                      <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+                        {lineCount.toLocaleString()}
                       </Typography>
                     </Box>
                   )}

--- a/frontend/src/pages/leaderboard/components/SubmissionSidebarContext.tsx
+++ b/frontend/src/pages/leaderboard/components/SubmissionSidebarContext.tsx
@@ -18,6 +18,7 @@ interface SubmissionSidebarStateType {
   navigationItems: NavigationItem[];
   navigationIndex: number;
   codes: Map<number, string>;
+  lineCounts: Map<number, number>;
   isOpen: boolean;
   isLoadingCodes: boolean;
   navigate: (newIndex: number, item: NavigationItem) => void;
@@ -40,6 +41,7 @@ export function SubmissionSidebarProvider({
   const [navigationItems, setNavigationItems] = useState<NavigationItem[]>([]);
   const [navigationIndex, setNavigationIndex] = useState(0);
   const [codes, setCodes] = useState<Map<number, string>>(new Map());
+  const [lineCounts, setLineCounts] = useState<Map<number, number>>(new Map());
   const [isLoadingCodes, setIsLoadingCodes] = useState(false);
   const codesRef = useRef(codes);
   codesRef.current = codes;
@@ -69,6 +71,15 @@ export function SubmissionSidebarProvider({
               const next = new Map(prev);
               for (const item of response?.results ?? []) {
                 next.set(item.submission_id, item.code);
+              }
+              return next;
+            });
+            setLineCounts((prev) => {
+              const next = new Map(prev);
+              for (const item of response?.results ?? []) {
+                if (typeof item.line_count === "number") {
+                  next.set(item.submission_id, item.line_count);
+                }
               }
               return next;
             });
@@ -113,6 +124,7 @@ export function SubmissionSidebarProvider({
           navigationItems,
           navigationIndex,
           codes,
+          lineCounts,
           isOpen: !!selectedSubmission,
           isLoadingCodes,
           navigate,

--- a/kernelboard/api/submission.py
+++ b/kernelboard/api/submission.py
@@ -195,7 +195,11 @@ def list_codes_route():
             logger.info(
                 "[list_codes] leaderboard is allowed, allow all users to see the leaderboard codes"
             )
-            results = list_codes(leaderboard_id, submission_ids)
+            results = list_codes(
+                leaderboard_id,
+                submission_ids,
+                include_line_count=True,
+            )
             return http_success(
                 data={"results": results},
             )
@@ -295,22 +299,33 @@ def list_submissions():
 def list_codes(
     leaderboard_id: int,
     submission_ids: List[int],
-) -> Tuple[List[dict[str, Any]], str]:
+    *,
+    include_line_count: bool = False,
+) -> List[dict[str, Any]]:
     conn = get_db_connection()
     with conn.cursor() as cur:
         sql, params = _query_list_codes(leaderboard_id, submission_ids)
         cur.execute(sql, params)
         rows = cur.fetchall()
-        items = [
-            {
+        items = []
+        for r in rows:
+            code = decodeCodeText(r[3])
+            item = {
                 "submission_id": r[0],
                 "leaderboard_id": r[1],
                 "code_id": r[2],
-                "code": decodeCodeText(r[3]),
+                "code": code,
             }
-            for r in rows
-        ]
+            if include_line_count:
+                item["line_count"] = count_lines_of_code(code)
+            items.append(item)
     return items
+
+
+def count_lines_of_code(code_text: str) -> int:
+    if not code_text:
+        return 0
+    return len(code_text.splitlines())
 
 
 def decodeCodeText(code_text):

--- a/tests/api/test_submission_api.py
+++ b/tests/api/test_submission_api.py
@@ -193,6 +193,51 @@ def _post_submission(client, form_overrides=None, file_tuple=None):
     )
 
 
+def _seed_code_submission(
+    app,
+    *,
+    leaderboard_id: int,
+    submission_id: int,
+    code_id: int,
+    code: str,
+) -> None:
+    with app.app_context():
+        conn = get_db_connection()
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO leaderboard.user_info (id, user_name)
+                    VALUES (%s, %s)
+                    ON CONFLICT (id) DO UPDATE
+                    SET user_name = EXCLUDED.user_name
+                    """,
+                    ("loc-test-user", "loc-test-user"),
+                )
+                cur.execute(
+                    """
+                    INSERT INTO leaderboard.code_files (id, code)
+                    VALUES (%s, %s)
+                    """,
+                    (code_id, code),
+                )
+                cur.execute(
+                    """
+                    INSERT INTO leaderboard.submission
+                        (id, leaderboard_id, file_name, user_id, code_id, submission_time, done)
+                    VALUES
+                        (%s, %s, %s, %s, %s, NOW(), TRUE)
+                    """,
+                    (
+                        submission_id,
+                        leaderboard_id,
+                        "loc_solution.py",
+                        "loc-test-user",
+                        code_id,
+                    ),
+                )
+
+
 def test_submission_happy_path(app, client, prepare):
     # auth + web_token default to True
     prepare()
@@ -311,6 +356,88 @@ def test_submission_upstream_non_200_maps_to_http_error(app, client, prepare):
     js = resp.get_json()
     assert js["code"] == 10000 + 400
     assert "invalid format" in js["message"].lower()
+
+
+# ----------------------------
+# /api/codes list tests
+# ----------------------------
+
+def test_list_codes_includes_line_count_for_ended_leaderboard(app, client, prepare):
+    prepare()
+    code = "import torch\n\nprint('ok')\n"
+    _seed_code_submission(
+        app,
+        leaderboard_id=339,
+        submission_id=910001,
+        code_id=910001,
+        code=code,
+    )
+
+    with app.app_context():
+        conn = get_db_connection()
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE leaderboard.leaderboard
+                    SET deadline = NOW() - INTERVAL '1 hour'
+                    WHERE id = 339
+                    """
+                )
+
+    resp = client.post(
+        "/api/codes",
+        json={"leaderboard_id": 339, "submission_ids": [910001]},
+    )
+
+    assert resp.status_code == http.HTTPStatus.OK
+    item = resp.get_json()["data"]["results"][0]
+    assert item["code"] == code
+    assert item["line_count"] == 3
+
+
+def test_list_codes_omits_line_count_for_active_admin_access(
+    app,
+    client,
+    monkeypatch,
+):
+    fake_admin = SimpleNamespace(
+        is_anonymous=False,
+        is_authenticated=True,
+        get_id=lambda: "discord:838132355075014667",
+    )
+    monkeypatch.setattr(flask_login.utils, "_get_user", lambda: fake_admin)
+
+    code = "import torch\nprint('active')\n"
+    _seed_code_submission(
+        app,
+        leaderboard_id=339,
+        submission_id=910002,
+        code_id=910002,
+        code=code,
+    )
+
+    with app.app_context():
+        conn = get_db_connection()
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE leaderboard.leaderboard
+                    SET deadline = NOW() + INTERVAL '1 hour'
+                    WHERE id = 339
+                    """
+                )
+
+    resp = client.post(
+        "/api/codes",
+        json={"leaderboard_id": 339, "submission_ids": [910002]},
+    )
+
+    assert resp.status_code == http.HTTPStatus.OK
+    item = resp.get_json()["data"]["results"][0]
+    assert item["code"] == code
+    assert "line_count" not in item
 
 
 # ----------------------------


### PR DESCRIPTION
## Summary
- Add optional line_count to /api/leaderboard ranking rows only when the leaderboard is concluded and public solution code is allowed.
- Show LOC directly in each ranking row when line_count is present, next to the existing ranking metadata.

## Validation
- git diff --check
- .venv/bin/ruff check kernelboard/api/leaderboard.py
- npm run lint
- npm run build

## Notes
- Backend route pytest still requires Docker for the Postgres/Redis fixtures; Docker is not running in this local environment.