### PR TITLE
Add ongoing competitions

### DIFF
--- a/frontend/src/pages/lectures/Lectures.tsx
+++ b/frontend/src/pages/lectures/Lectures.tsx
@@ -133,8 +133,16 @@ const inPersonEvents: InPersonEvent[] = [
 
 const kernelCompetitions: Competition[] = [
   {
+    title: "One Layer Deeper",
+    startDate: "2026-07-16",
+    endDate: "2026-08-30",
+    location: "Online",
+    lumaUrl: "https://onelayerdeeper.ai/",
+  },
+  {
     title: "Linear Algebra Kernels For The Age Of Research",
     startDate: "2026-06-12",
+    endDate: "2026-07-30",
     location: "Online",
     lumaUrl: "/news/linear-algebra-kernels-age-of-research",
     description:


### PR DESCRIPTION
## Summary

- add One Layer Deeper to the ongoing competition list, linking to its competition site and ending August 30, 2026
- set the Linear Algebra Kernels For The Age Of Research competition to end July 30, 2026 while retaining its blog link

## Why

The events page should show both currently active competitions with their correct closing dates so they automatically leave the active list after their deadlines.

## Validation

- `npm run lint -- --no-fix`
- `npm run build`