### PR TITLE
Move sponsor message to site footer

### DIFF
--- a/frontend/src/components/app-layout/Footer.test.tsx
+++ b/frontend/src/components/app-layout/Footer.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material";
+import { describe, expect, it } from "vitest";
+import { appTheme } from "../common/styles/theme";
+import Footer from "./Footer";
+
+describe("Footer", () => {
+  it("shows the site-wide sponsor message and contact link", () => {
+    render(
+      <ThemeProvider theme={appTheme}>
+        <Footer />
+      </ThemeProvider>,
+    );
+
+    expect(
+      screen.getByText(/Modal, Core Automation, and Northflank/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "reach out" })).toHaveAttribute(
+      "href",
+      "mailto:mark@gpumode.com",
+    );
+  });
+});

--- a/frontend/src/components/app-layout/Footer.tsx
+++ b/frontend/src/components/app-layout/Footer.tsx
@@ -29,6 +29,14 @@ export default function Footer() {
   return (
     <FooterBox>
       <ConstrainedContainer>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Thank you to Modal, Core Automation, and Northflank for supporting us.
+          To sponsor GPU MODE, please{" "}
+          <Link href="mailto:mark@gpumode.com" fontWeight={600}>
+            reach out
+          </Link>
+          .
+        </Typography>
         <Box
           sx={{
             display: "flex",

--- a/frontend/src/pages/home/Home.test.tsx
+++ b/frontend/src/pages/home/Home.test.tsx
@@ -149,15 +149,6 @@ describe("Home", () => {
     renderWithProviders(<Home />);
 
     expect(screen.getByText("Leaderboards")).toBeInTheDocument();
-    expect(
-      screen.getByText(/GPU MODE's mission is to make high-performance/i),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/Core Automation/i)).toBeInTheDocument();
-    expect(screen.getByText(/Northflank/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /reach out/i })).toHaveAttribute(
-      "href",
-      "mailto:mark@gpumode.com",
-    );
     expect(screen.getByText("test-leaderboard")).toBeInTheDocument();
     expect(screen.getByText("T4, L4")).toBeInTheDocument();
     expect(screen.getByText("alice")).toBeInTheDocument();

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -128,41 +128,6 @@ export default function Home() {
   return (
     <ConstrainedContainer>
       <Box>
-        <Box
-          sx={{
-            border: 1,
-            borderColor: "divider",
-            borderRadius: 1,
-            bgcolor: "background.paper",
-            px: 2,
-            py: 1.5,
-            width: "100%",
-            mb: 3,
-          }}
-        >
-          <Typography
-            variant="body2"
-            color="text.secondary"
-            sx={{ lineHeight: 1.6 }}
-          >
-            GPU MODE&apos;s mission is to make high-performance GPU programming
-            more accessible.
-            <br />
-            We rely on donations and sponsorships to fund community compute,
-            lectures, kernel competitions, working groups, and events.
-            <br />
-            Thank you to Modal, Core Automation, and Northflank for supporting
-            us. To sponsor GPU MODE, please{" "}
-            <Box
-              component="a"
-              href="mailto:mark@gpumode.com"
-              sx={{ color: "primary.main", fontWeight: 600 }}
-            >
-              reach out
-            </Box>
-            .
-          </Typography>
-        </Box>
         <Typography variant="h1" component="h1" sx={{ mb: 3 }}>
           Leaderboards
         </Typography>


### PR DESCRIPTION
## Summary

- remove the standalone sponsor panel from the homepage
- add the sponsor acknowledgment to the shared site footer
- link “reach out” to `mailto:mark@gpumode.com`
- add focused footer test coverage

## Why

The sponsor acknowledgment should be visible consistently across Kernelboard without taking up a dedicated panel on the homepage.

## User impact

Every page using the shared application layout now shows the sponsor message in its footer, while the homepage starts directly with the leaderboard content.

## Validation

- `npm test -- --run src/pages/home/Home.test.tsx src/components/app-layout/Footer.test.tsx` (22 tests passed)
- `npm run lint`
- `npm run build`